### PR TITLE
Fix Paper/BG color picker popover anchoring

### DIFF
--- a/celstomp/celstomp-app.js
+++ b/celstomp/celstomp-app.js
@@ -1613,11 +1613,8 @@
                 e.stopPropagation();
                 const startHex = normalizeToHex(canvasBgColor);
                 requestAnimationFrame(() => {
-                    openLiveColorDialog({
-                        initialHex: startHex,
-                        onLive: hex => setCanvasBgColor(hex),
-                        onCommit: hex => setCanvasBgColor(hex),
-                        onCancel: () => setCanvasBgColor(startHex)
+                    openColorPickerAtElement(btn, startHex, hex => {
+                        setCanvasBgColor(hex);
                     });
                 });
             });


### PR DESCRIPTION
as mentioned in issue #11 The Paper/BG color picker popover was rendering at the top of the viewport instead of being positioned relative to the Paper color control. 

This change anchors the popover to the Paper color box (matching the main color picker behavior), so it opens aligned with the control and stays correctly positioned during scrolling and on mobile.