### PR TITLE
Fix canvas aspect sync between frame and drawable surface (Fixes #35)

### DIFF
--- a/celstomp/celstomp-app.js
+++ b/celstomp/celstomp-app.js
@@ -19,9 +19,6 @@
     }
     
     ready(() => {
-        let contentW = 960;
-        let contentH = 540;
-        
         const stageEl = $("stage");
 
         function ensureChild(parent, el) {


### PR DESCRIPTION
## Description

Fixes a canvas sizing desync where changing **Canvas Aspect** updated the visual frame/bounds but not the actual drawable surface. The desync was caused by duplicate (shadowed) `contentW/contentH` state in app scope, so aspect updates weren’t propagating to the shared runtime dimensions used by the renderer.

This PR removes the shadowing and ensures aspect changes update the shared content size used by both:

* bounds/frame rendering, and
* composite drawing/render surface.

Fixes #35 

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Code refactoring
* [ ] Performance improvement
* [ ] Other (please describe):

## Changes Made

* Removed local `contentW/contentH` shadowing in `celstomp/celstomp-app.js`.
* Ensured Canvas Aspect changes update the shared content size values consumed by:

  * bounds/frame rendering, and
  * composite drawing/render surface.
* Result: the Canvas Aspect frame and the drawable region remain exactly aligned.

## Testing

* [x] Tested in Chrome
* [ ] Tested in Firefox
* [ ] Tested in Safari
* [ ] Tested in Edge
* [ ] Tested on mobile devices (if applicable)

**Test Configuration:**

* OS: Zorin OS (Linux)
* Browser: Chromium-based (local)
* Additional check: `npm run build` passes

## Screenshots (if applicable)

<img width="1920" height="897" alt="image" src="https://github.com/user-attachments/assets/21e6a5c8-c9b2-463a-9b78-53ef5989c217" />

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have tested my changes thoroughly
* [ ] Any dependent changes have been merged and published

## Related Issues

* Fixes #35

## Additional Notes

The mismatch came from maintaining duplicate content-dimension state (app scope vs shared runtime scope). Removing the shadowing ensures aspect updates propagate everywhere that relies on content dimensions.
