### PR TITLE
Add flip selection with H/V keyboard shortcuts

### DIFF
--- a/celstomp/parts/modals.js
+++ b/celstomp/parts/modals.js
@@ -71,12 +71,17 @@ document.getElementById('part-modals').innerHTML = `
         <div class="shortcutRow"><kbd>R</kbd><span>Next Frame</span></div>
       </div>
       <div class="shortcutSection">
+        <h4>Selection</h4>
+        <div class="shortcutRow"><kbd>H</kbd><span>Flip Horizontal</span></div>
+        <div class="shortcutRow"><kbd>V</kbd><span>Flip Vertical</span></div>
+        <div class="shortcutRow"><kbd>Del</kbd><span>Delete Selection</span></div>
+      </div>
+      <div class="shortcutSection">
         <h4>Actions</h4>
         <div class="shortcutRow"><kbd>Space</kbd><span>Play/Pause</span></div>
         <div class="shortcutRow"><kbd>Ctrl+Z</kbd><span>Undo</span></div>
         <div class="shortcutRow"><kbd>Ctrl+Y</kbd><span>Redo</span></div>
         <div class="shortcutRow"><kbd>Ctrl+Shift+Z</kbd><span>Redo</span></div>
-        <div class="shortcutRow"><kbd>Del</kbd><span>Delete Selection/Color</span></div>
         <div class="shortcutRow"><kbd>F</kbd><span>Fill Current Frame</span></div>
         <div class="shortcutRow"><kbd>O</kbd><span>Toggle Onion</span></div>
       </div>


### PR DESCRIPTION
## Description
Add keyboard shortcuts to flip rectangular selections horizontally (H key) or vertically (V key).

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- Add flipSelection() function in interaction-shortcuts.js
- Wire H and V key handlers when selection is active
- Update keyboard shortcuts modal to document new shortcuts

## Testing
- [x] Tested in Firefox

**Test Configuration:**
- OS: Windows 10
- Browser: Firefox

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested my changes thoroughly

## Related Issues
N/A
