### PR TITLE
Add line drawing tool

### DIFF
--- a/celstomp/celstomp-app.js
+++ b/celstomp/celstomp-app.js
@@ -358,6 +358,7 @@
             bctx.fillRect(0, 0, contentW, contentH);
             bctx.strokeRect(0, 0, contentW, contentH);
             drawRectSelectionOverlay(fxctx);
+            drawLineToolPreview(fxctx);
         }
 
         function onionCompositeOperation() {
@@ -404,6 +405,9 @@
         function clearFx() {
             fxctx.setTransform(1, 0, 0, 1, 0, 0);
             fxctx.clearRect(0, 0, fxCanvas.width, fxCanvas.height);
+            setTransform(fxctx);
+            drawRectSelectionOverlay(fxctx);
+            drawLineToolPreview(fxctx);
         }
 
         function wireBrushButtonRightClick() {

--- a/celstomp/css/components/tools.css
+++ b/celstomp/css/components/tools.css
@@ -126,6 +126,22 @@
   cursor: pointer;
 }
 
+#islandToolsSlot #toolSeg > label svg {
+  width: 20px;
+  height: 20px;
+  color: rgba(255,255,255,0.85);
+  position: relative;
+  z-index: 1;
+}
+
+#islandToolsSlot #toolSeg > label:has(svg) {
+  background-image: none;
+}
+
+#islandToolsSlot #toolSeg > label:has(svg)::before {
+  display: none;
+}
+
 #islandToolsSlot #toolSeg > label::before{
   content: "";
   width: 20px;

--- a/celstomp/js/tools/brush-helper.js
+++ b/celstomp/js/tools/brush-helper.js
@@ -315,9 +315,9 @@ function getBrushSizeForPreview(toolKind) {
 function updateBrushPreview() {
     if (!_brushPrevEl || !_brushPrevCanvas) return;
     const toolKind = getActiveToolKindForPreview();
-    const isBrush = toolKind === "brush";
+    const showForTools = toolKind === "brush" || toolKind === "eraser" || toolKind === "line";
     const isEraser = toolKind === "eraser";
-    if (!isBrush && !isEraser) {
+    if (!showForTools) {
         _brushPrevEl.style.display = "none";
         return;
     }

--- a/celstomp/js/ui/interaction-shortcuts.js
+++ b/celstomp/js/ui/interaction-shortcuts.js
@@ -600,12 +600,13 @@ function wireKeyboardShortcuts() {
   const toolByKey = {
       1: "brush",
       2: "eraser",
-      3: "fill-brush",
-      4: "fill-eraser",
-      5: "lasso-fill",
-      6: "lasso-erase",
-      7: "rect-select",
-      8: "eyedropper"
+      3: "line",
+      4: "fill-brush",
+      5: "fill-eraser",
+      6: "lasso-fill",
+      7: "lasso-erase",
+      8: "rect-select",
+      9: "eyedropper"
   };
   document.addEventListener("keydown", e => {
       if (e.defaultPrevented) return;
@@ -692,25 +693,32 @@ function onWindowKeyDown(e) {
                 if (isDigit(3)) {
                     e.preventDefault();
                     pickTool({
+                        id: "tool-line",
+                        value: "line"
+                    });
+                }
+                if (isDigit(4)) {
+                    e.preventDefault();
+                    pickTool({
                         id: "tool-fillbrush",
                         value: "fill-brush"
                     });
                 }
-                if (isDigit(4)) {
+                if (isDigit(5)) {
                     e.preventDefault();
                     pickTool({
                         id: "tool-filleraser",
                         value: "fill-eraser"
                     });
                 }
-                if (isDigit(5)) {
+                if (isDigit(6)) {
                     e.preventDefault();
                     pickTool({
                         id: "tool-lassoFill",
                         value: "lasso-fill"
                     });
                 }
-                if (isDigit(6)) {
+                if (isDigit(7)) {
                     e.preventDefault();
                     pickTool({
                         id: "tool-lassoErase",
@@ -718,14 +726,14 @@ function onWindowKeyDown(e) {
                         value: "lasso-erase"
                     });
                 }
-                if (isDigit(7)) {
+                if (isDigit(8)) {
                     e.preventDefault();
                     pickTool({
                         id: "tool-rectSelect",
                         value: "rect-select"
                     });
                 }
-                if (isDigit(8)) {
+                if (isDigit(9)) {
                     e.preventDefault();
                     pickTool({
                         id: "tool-eyedropper",

--- a/celstomp/js/ui/ui-components.js
+++ b/celstomp/js/ui/ui-components.js
@@ -4,6 +4,7 @@
     const tools = [
         { id: 'tool-brush', val: 'brush', label: 'Brush', checked: true },
         { id: 'tool-eraser', val: 'eraser', label: 'Eraser' },
+        { id: 'tool-line', val: 'line', label: 'Line', icon: '<svg viewBox="0 0 24 24" width="18" height="18"><line x1="4" y1="20" x2="20" y2="4" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>' },
         { id: 'tool-fillbrush', val: 'fill-brush', label: 'Fill Brush' },
         { id: 'tool-filleraser', val: 'fill-eraser', label: 'Eraser Fill' },
         { id: 'tool-lassoFill', val: 'lasso-fill', label: 'Lasso Fill' },
@@ -27,7 +28,12 @@
             const lbl = document.createElement('label');
             lbl.htmlFor = t.id;
             lbl.dataset.tool = t.val;
-            lbl.textContent = t.label;
+            lbl.setAttribute('aria-label', t.label);
+            if (t.icon) {
+                lbl.innerHTML = t.icon;
+            } else {
+                lbl.textContent = t.label;
+            }
 
             if (t.val === 'brush') lbl.id = 'toolBrushLabel';
             if (t.val === 'eraser') lbl.id = 'toolEraserLabel';

--- a/celstomp/parts/modals.js
+++ b/celstomp/parts/modals.js
@@ -52,12 +52,13 @@ document.getElementById('part-modals').innerHTML = `
         <h4>Tools</h4>
         <div class="shortcutRow"><kbd>1</kbd><span>Brush</span></div>
         <div class="shortcutRow"><kbd>2</kbd><span>Eraser</span></div>
-        <div class="shortcutRow"><kbd>3</kbd><span>Fill Brush</span></div>
-        <div class="shortcutRow"><kbd>4</kbd><span>Fill Eraser</span></div>
-        <div class="shortcutRow"><kbd>5</kbd><span>Lasso Fill</span></div>
-        <div class="shortcutRow"><kbd>6</kbd><span>Lasso Erase</span></div>
-        <div class="shortcutRow"><kbd>7</kbd><span>Rect Select</span></div>
-        <div class="shortcutRow"><kbd>8</kbd><span>Eyedropper</span></div>
+        <div class="shortcutRow"><kbd>3</kbd><span>Line</span></div>
+        <div class="shortcutRow"><kbd>4</kbd><span>Fill Brush</span></div>
+        <div class="shortcutRow"><kbd>5</kbd><span>Fill Eraser</span></div>
+        <div class="shortcutRow"><kbd>6</kbd><span>Lasso Fill</span></div>
+        <div class="shortcutRow"><kbd>7</kbd><span>Lasso Erase</span></div>
+        <div class="shortcutRow"><kbd>8</kbd><span>Rect Select</span></div>
+        <div class="shortcutRow"><kbd>9</kbd><span>Eyedropper</span></div>
       </div>
       <div class="shortcutSection">
         <h4>Navigation</h4>


### PR DESCRIPTION
## Description
Add a dedicated line drawing tool accessible via key 3.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- Add line tool to tool selector with SVG icon
- Implement line drawing logic in pointer-events.js
- Add cursor preview support in brush-helper.js
- Style tool icon in tools.css

## Testing
- [x] Tested in Firefox

**Test Configuration:**
- OS: Windows 10
- Browser: Firefox

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested my changes thoroughly

## Related Issues
N/A
