### PR TITLE
Add rectangle drawing tool

### DIFF
--- a/celstomp/celstomp-app.js
+++ b/celstomp/celstomp-app.js
@@ -358,6 +358,7 @@
             bctx.fillRect(0, 0, contentW, contentH);
             bctx.strokeRect(0, 0, contentW, contentH);
             drawRectSelectionOverlay(fxctx);
+            drawRectToolPreview(fxctx);
         }
 
         function onionCompositeOperation() {
@@ -404,6 +405,9 @@
         function clearFx() {
             fxctx.setTransform(1, 0, 0, 1, 0, 0);
             fxctx.clearRect(0, 0, fxCanvas.width, fxCanvas.height);
+            setTransform(fxctx);
+            drawRectSelectionOverlay(fxctx);
+            drawRectToolPreview(fxctx);
         }
 
         function wireBrushButtonRightClick() {

--- a/celstomp/celstomp-app.js
+++ b/celstomp/celstomp-app.js
@@ -149,6 +149,9 @@
         const eraserSizeInput = $("eraserSize");
         const toolOpacityRange = $("toolOpacityRange");
         const toolAngleRange = $("toolAngleRange");
+        const toolOpacityRow = toolOpacityRange?.closest(".sideRangeRow") || null;
+        const toolAngleRow = toolAngleRange?.closest(".sideRangeRow") || null;
+        const brushFoldSection = toolFoldBrushesBtn?.closest(".toolFold") || null;
         const eraserVal = $("eraserVal");
     
 
@@ -183,16 +186,25 @@
         function refreshToolSettingsUI() {
             const isBrush = tool === "brush";
             const isEraser = tool === "eraser";
-            if (toolSettingsSection) toolSettingsSection.hidden = !(isBrush || isEraser);
-            if (!isBrush && !isEraser) return;
+            const isLine = tool === "line";
+            const isRect = tool === "rect";
+            const isShapeTool = isLine || isRect;
+            const showsBrushSettings = isBrush || isShapeTool;
+            if (toolSettingsSection) toolSettingsSection.hidden = !(showsBrushSettings || isEraser);
+            if (brushFoldSection) brushFoldSection.hidden = isShapeTool;
+            if (toolOpacityRow) toolOpacityRow.hidden = isShapeTool;
+            if (toolAngleRow) toolAngleRow.hidden = isShapeTool;
+            if (!showsBrushSettings && !isEraser) return;
             const s = isEraser ? eraserSettings : brushSettings;
-            if (toolSettingsTitle) toolSettingsTitle.textContent = isEraser ? "Eraser" : "Brushes";
+            if (toolSettingsTitle) toolSettingsTitle.textContent = isEraser ? "Eraser" : isShapeTool ? "Shape Tool" : "Brushes";
             safeSetValue(brushSizeInput, s.size);
             safeSetValue(brushSizeNumInput, s.size);
             safeSetValue(toolOpacityRange, Math.round(s.opacity * 100));
             safeSetValue(toolAngleRange, s.angle);
-            const activeShape = document.querySelector('input[name="brushShape"][value="' + s.shape + '"]');
-            if (activeShape) activeShape.checked = true;
+            if (!isShapeTool) {
+                const activeShape = document.querySelector('input[name="brushShape"][value="' + s.shape + '"]');
+                if (activeShape) activeShape.checked = true;
+            }
         }
         function setFoldExpanded(btn, body, open) {
             if (!btn || !body) return;

--- a/celstomp/css/components/tools.css
+++ b/celstomp/css/components/tools.css
@@ -126,6 +126,22 @@
   cursor: pointer;
 }
 
+#islandToolsSlot #toolSeg > label svg {
+  width: 20px;
+  height: 20px;
+  color: rgba(255,255,255,0.85);
+  position: relative;
+  z-index: 1;
+}
+
+#islandToolsSlot #toolSeg > label:has(svg) {
+  background-image: none;
+}
+
+#islandToolsSlot #toolSeg > label:has(svg)::before {
+  display: none;
+}
+
 #islandToolsSlot #toolSeg > label::before{
   content: "";
   width: 20px;

--- a/celstomp/js/input/pointer-events.js
+++ b/celstomp/js/input/pointer-events.js
@@ -277,6 +277,7 @@ function startStroke(e) {
       activeSubColor[activeLayer] = strokeHex;
       ensureSublayer(activeLayer, strokeHex);
       renderLayerSwatches(activeLayer);
+      beginGlobalHistoryStep(activeLayer, currentFrame, strokeHex);
       rectToolStart = { x, y };
       rectToolPreview = { x, y };
       return;
@@ -360,6 +361,7 @@ function startStroke(e) {
       activeSubColor[activeLayer] = strokeHex;
       ensureSublayer(activeLayer, strokeHex);
       renderLayerSwatches(activeLayer);
+      beginGlobalHistoryStep(activeLayer, currentFrame, strokeHex);
       lineToolStart = { x, y };
       lineToolPreview = { x, y };
       return;
@@ -499,11 +501,12 @@ function continueStroke(e) {
 function endStroke() {
   if (!isDrawing) return;
   isDrawing = false;
-  commitGlobalHistoryStep();
   const endKey = strokeHex;
-  strokeHex = null;
-  queueRenderAll();
-  updateTimelineHasContent(currentFrame);
+  const finishingRect = tool === "rect" && rectToolStart && rectToolPreview;
+  const finishingLine = tool === "line" && lineToolStart && lineToolPreview;
+  if (!finishingRect && !finishingLine) {
+      commitGlobalHistoryStep();
+  }
   if (tool === "rect" && rectToolStart && rectToolPreview) {
       const hex = strokeHex || activeSubColor?.[activeLayer] || colorToHex(currentColor);
       const off = getFrameCanvas(activeLayer, currentFrame, hex);
@@ -514,10 +517,14 @@ function endStroke() {
       ctx.beginPath();
       ctx.rect(rectToolStart.x, rectToolStart.y, rectToolPreview.x - rectToolStart.x, rectToolPreview.y - rectToolStart.y);
       ctx.stroke();
-      off._hasContent = true;
+      markFrameHasContent(activeLayer, currentFrame, hex);
+      markGlobalHistoryDirty();
+      commitGlobalHistoryStep();
       rectToolStart = null;
       rectToolPreview = null;
+      strokeHex = null;
       queueRenderAll();
+      updateTimelineHasContent(currentFrame);
       lastPt = null;
       stabilizedPt = null;
       return;
@@ -541,12 +548,18 @@ function endStroke() {
       ctx.lineTo(lineToolPreview.x, lineToolPreview.y);
       ctx.stroke();
       markFrameHasContent(activeLayer, currentFrame, hex);
+      markGlobalHistoryDirty();
+      commitGlobalHistoryStep();
       lineToolStart = null;
       lineToolPreview = null;
+      strokeHex = null;
       queueRenderAll();
       updateTimelineHasContent(currentFrame);
       return;
   }
+  strokeHex = null;
+  queueRenderAll();
+  updateTimelineHasContent(currentFrame);
   if (tool === "lasso-erase" && lassoActive) {
       lassoActive = false;
       applyLassoErase();
@@ -1579,8 +1592,8 @@ function drawRectToolPreview(ctx) {
     if (!rectToolStart || !rectToolPreview) return;
     ctx.save();
     ctx.strokeStyle = colorToHex(currentColor);
-    ctx.lineWidth = Math.max(1, brushSize) / Math.max(getZoom(), 1);
-    ctx.setLineDash([4 / Math.max(getZoom(), 1), 2 / Math.max(getZoom(), 1)]);
+    ctx.lineWidth = Math.max(1, brushSize);
+    ctx.globalAlpha = 0.5;
     ctx.beginPath();
     ctx.rect(rectToolStart.x, rectToolStart.y, rectToolPreview.x - rectToolStart.x, rectToolPreview.y - rectToolStart.y);
     ctx.stroke();

--- a/celstomp/js/tools/brush-helper.js
+++ b/celstomp/js/tools/brush-helper.js
@@ -315,7 +315,7 @@ function getBrushSizeForPreview(toolKind) {
 function updateBrushPreview() {
     if (!_brushPrevEl || !_brushPrevCanvas) return;
     const toolKind = getActiveToolKindForPreview();
-    const showForTools = toolKind === "brush" || toolKind === "eraser" || toolKind === "line";
+    const showForTools = toolKind === "brush" || toolKind === "eraser" || toolKind === "line" || toolKind === "rect";
     const isEraser = toolKind === "eraser";
     if (!showForTools) {
         _brushPrevEl.style.display = "none";

--- a/celstomp/js/ui/interaction-shortcuts.js
+++ b/celstomp/js/ui/interaction-shortcuts.js
@@ -600,14 +600,13 @@ function wireKeyboardShortcuts() {
   const toolByKey = {
       1: "brush",
       2: "eraser",
-      3: "line",
+      3: "fill-brush",
       4: "rect",
-      5: "fill-brush",
-      6: "fill-eraser",
-      7: "lasso-fill",
-      8: "lasso-erase",
-      9: "rect-select",
-      0: "eyedropper"
+      5: "fill-eraser",
+      6: "lasso-fill",
+      7: "lasso-erase",
+      8: "rect-select",
+      9: "eyedropper"
   };
   document.addEventListener("keydown", e => {
       if (e.defaultPrevented) return;

--- a/celstomp/js/ui/interaction-shortcuts.js
+++ b/celstomp/js/ui/interaction-shortcuts.js
@@ -600,13 +600,14 @@ function wireKeyboardShortcuts() {
   const toolByKey = {
       1: "brush",
       2: "eraser",
-      3: "fill-brush",
+      3: "line",
       4: "rect",
-      5: "fill-eraser",
-      6: "lasso-fill",
-      7: "lasso-erase",
-      8: "rect-select",
-      9: "eyedropper"
+      5: "fill-brush",
+      6: "fill-eraser",
+      7: "lasso-fill",
+      8: "lasso-erase",
+      9: "rect-select",
+      0: "eyedropper"
   };
   document.addEventListener("keydown", e => {
       if (e.defaultPrevented) return;

--- a/celstomp/js/ui/interaction-shortcuts.js
+++ b/celstomp/js/ui/interaction-shortcuts.js
@@ -601,11 +601,12 @@ function wireKeyboardShortcuts() {
       1: "brush",
       2: "eraser",
       3: "fill-brush",
-      4: "fill-eraser",
-      5: "lasso-fill",
-      6: "lasso-erase",
-      7: "rect-select",
-      8: "eyedropper"
+      4: "rect",
+      5: "fill-eraser",
+      6: "lasso-fill",
+      7: "lasso-erase",
+      8: "rect-select",
+      9: "eyedropper"
   };
   document.addEventListener("keydown", e => {
       if (e.defaultPrevented) return;

--- a/celstomp/js/ui/ui-components.js
+++ b/celstomp/js/ui/ui-components.js
@@ -4,6 +4,7 @@
     const tools = [
         { id: 'tool-brush', val: 'brush', label: 'Brush', checked: true },
         { id: 'tool-eraser', val: 'eraser', label: 'Eraser' },
+        { id: 'tool-rect', val: 'rect', label: 'Rect', icon: '<svg viewBox="0 0 24 24" width="18" height="18"><rect x="3" y="5" width="18" height="14" rx="2" fill="none" stroke="currentColor" stroke-width="2"/></svg>' },
         { id: 'tool-fillbrush', val: 'fill-brush', label: 'Fill Brush' },
         { id: 'tool-filleraser', val: 'fill-eraser', label: 'Eraser Fill' },
         { id: 'tool-lassoFill', val: 'lasso-fill', label: 'Lasso Fill' },
@@ -27,7 +28,12 @@
             const lbl = document.createElement('label');
             lbl.htmlFor = t.id;
             lbl.dataset.tool = t.val;
-            lbl.textContent = t.label;
+            lbl.setAttribute('aria-label', t.label);
+            if (t.icon) {
+                lbl.innerHTML = t.icon;
+            } else {
+                lbl.textContent = t.label;
+            }
 
             if (t.val === 'brush') lbl.id = 'toolBrushLabel';
             if (t.val === 'eraser') lbl.id = 'toolEraserLabel';

--- a/celstomp/parts/modals.js
+++ b/celstomp/parts/modals.js
@@ -52,13 +52,14 @@ document.getElementById('part-modals').innerHTML = `
         <h4>Tools</h4>
         <div class="shortcutRow"><kbd>1</kbd><span>Brush</span></div>
         <div class="shortcutRow"><kbd>2</kbd><span>Eraser</span></div>
-        <div class="shortcutRow"><kbd>3</kbd><span>Fill Brush</span></div>
+        <div class="shortcutRow"><kbd>3</kbd><span>Line</span></div>
         <div class="shortcutRow"><kbd>4</kbd><span>Rect</span></div>
-        <div class="shortcutRow"><kbd>5</kbd><span>Fill Eraser</span></div>
-        <div class="shortcutRow"><kbd>6</kbd><span>Lasso Fill</span></div>
-        <div class="shortcutRow"><kbd>7</kbd><span>Lasso Erase</span></div>
-        <div class="shortcutRow"><kbd>8</kbd><span>Rect Select</span></div>
-        <div class="shortcutRow"><kbd>9</kbd><span>Eyedropper</span></div>
+        <div class="shortcutRow"><kbd>5</kbd><span>Fill Brush</span></div>
+        <div class="shortcutRow"><kbd>6</kbd><span>Fill Eraser</span></div>
+        <div class="shortcutRow"><kbd>7</kbd><span>Lasso Fill</span></div>
+        <div class="shortcutRow"><kbd>8</kbd><span>Lasso Erase</span></div>
+        <div class="shortcutRow"><kbd>9</kbd><span>Rect Select</span></div>
+        <div class="shortcutRow"><kbd>0</kbd><span>Eyedropper</span></div>
       </div>
       <div class="shortcutSection">
         <h4>Navigation</h4>

--- a/celstomp/parts/modals.js
+++ b/celstomp/parts/modals.js
@@ -53,11 +53,12 @@ document.getElementById('part-modals').innerHTML = `
         <div class="shortcutRow"><kbd>1</kbd><span>Brush</span></div>
         <div class="shortcutRow"><kbd>2</kbd><span>Eraser</span></div>
         <div class="shortcutRow"><kbd>3</kbd><span>Fill Brush</span></div>
-        <div class="shortcutRow"><kbd>4</kbd><span>Fill Eraser</span></div>
-        <div class="shortcutRow"><kbd>5</kbd><span>Lasso Fill</span></div>
-        <div class="shortcutRow"><kbd>6</kbd><span>Lasso Erase</span></div>
-        <div class="shortcutRow"><kbd>7</kbd><span>Rect Select</span></div>
-        <div class="shortcutRow"><kbd>8</kbd><span>Eyedropper</span></div>
+        <div class="shortcutRow"><kbd>4</kbd><span>Rect</span></div>
+        <div class="shortcutRow"><kbd>5</kbd><span>Fill Eraser</span></div>
+        <div class="shortcutRow"><kbd>6</kbd><span>Lasso Fill</span></div>
+        <div class="shortcutRow"><kbd>7</kbd><span>Lasso Erase</span></div>
+        <div class="shortcutRow"><kbd>8</kbd><span>Rect Select</span></div>
+        <div class="shortcutRow"><kbd>9</kbd><span>Eyedropper</span></div>
       </div>
       <div class="shortcutSection">
         <h4>Navigation</h4>

--- a/celstomp/parts/modals.js
+++ b/celstomp/parts/modals.js
@@ -52,14 +52,13 @@ document.getElementById('part-modals').innerHTML = `
         <h4>Tools</h4>
         <div class="shortcutRow"><kbd>1</kbd><span>Brush</span></div>
         <div class="shortcutRow"><kbd>2</kbd><span>Eraser</span></div>
-        <div class="shortcutRow"><kbd>3</kbd><span>Line</span></div>
+        <div class="shortcutRow"><kbd>3</kbd><span>Fill Brush</span></div>
         <div class="shortcutRow"><kbd>4</kbd><span>Rect</span></div>
-        <div class="shortcutRow"><kbd>5</kbd><span>Fill Brush</span></div>
-        <div class="shortcutRow"><kbd>6</kbd><span>Fill Eraser</span></div>
-        <div class="shortcutRow"><kbd>7</kbd><span>Lasso Fill</span></div>
-        <div class="shortcutRow"><kbd>8</kbd><span>Lasso Erase</span></div>
-        <div class="shortcutRow"><kbd>9</kbd><span>Rect Select</span></div>
-        <div class="shortcutRow"><kbd>0</kbd><span>Eyedropper</span></div>
+        <div class="shortcutRow"><kbd>5</kbd><span>Fill Eraser</span></div>
+        <div class="shortcutRow"><kbd>6</kbd><span>Lasso Fill</span></div>
+        <div class="shortcutRow"><kbd>7</kbd><span>Lasso Erase</span></div>
+        <div class="shortcutRow"><kbd>8</kbd><span>Rect Select</span></div>
+        <div class="shortcutRow"><kbd>9</kbd><span>Eyedropper</span></div>
       </div>
       <div class="shortcutSection">
         <h4>Navigation</h4>


### PR DESCRIPTION
## Description
Add a rectangle drawing tool accessible via key 4.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- Add rectangle tool to tool selector with SVG icon
- Implement rectangle drawing logic in pointer-events.js
- Add cursor preview support in brush-helper.js
- Style tool icon in tools.css

## Testing
- [x] Tested in Firefox

**Test Configuration:**
- OS: Windows 10
- Browser: Firefox

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested my changes thoroughly

## Related Issues
N/A
