### PR TITLE
Add text tool with rich editor

### DIFF
--- a/celstomp/css/components/overlays.css
+++ b/celstomp/css/components/overlays.css
@@ -127,6 +127,124 @@
   line-height: 1.35;
 }
 
+.canvasTextEntry {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.32);
+  z-index: 9400;
+}
+
+.canvasTextEntry.open {
+  display: flex;
+}
+
+.canvasTextEntryCard {
+  width: min(420px, calc(100vw - 24px));
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(16, 20, 28, 0.96);
+  border-radius: 10px;
+  box-shadow: 0 16px 42px rgba(0, 0, 0, 0.45);
+  padding: 12px;
+  display: grid;
+  gap: 10px;
+}
+
+.canvasTextEntryLabel {
+  font-size: 12px;
+  color: #c7d0db;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.canvasTextEntryInput {
+  width: 100%;
+  min-height: 36px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(0, 0, 0, 0.28);
+  color: #e2e8f0;
+  border-radius: 8px;
+  padding: 8px 10px;
+}
+
+.canvasTextEntryInput:focus {
+  outline: none;
+  border-color: rgba(92, 179, 255, 0.8);
+  box-shadow: 0 0 0 2px rgba(92, 179, 255, 0.2);
+}
+
+.canvasTextEntryOptions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.canvasTextEntryOpt {
+  display: grid;
+  gap: 4px;
+}
+
+.canvasTextEntryOpt > span {
+  font-size: 11px;
+  color: #b7c3d2;
+  letter-spacing: 0.03em;
+}
+
+.canvasTextEntrySelect,
+.canvasTextEntryNum {
+  width: 100%;
+  min-height: 32px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(0, 0, 0, 0.28);
+  color: #e2e8f0;
+  border-radius: 8px;
+  padding: 6px 8px;
+}
+
+.canvasTextEntrySelect:focus,
+.canvasTextEntryNum:focus {
+  outline: none;
+  border-color: rgba(92, 179, 255, 0.8);
+  box-shadow: 0 0 0 2px rgba(92, 179, 255, 0.2);
+}
+
+.canvasTextEntryOptCheck {
+  align-items: center;
+  grid-template-columns: auto 1fr;
+  gap: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 6px 8px;
+}
+
+.canvasTextEntryOptCheck input {
+  margin: 0;
+}
+
+.canvasTextEntryActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.canvasTextEntryBtn {
+  min-height: 34px;
+  padding: 0 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.06);
+  color: #d0d8e2;
+}
+
+.canvasTextEntryBtnPrimary {
+  border-color: rgba(92, 179, 255, 0.6);
+  background: rgba(92, 179, 255, 0.18);
+  color: #9fd5ff;
+}
+
 /* Modal Card */
 .modalBackdrop{
   position: fixed;

--- a/celstomp/css/components/tools.css
+++ b/celstomp/css/components/tools.css
@@ -126,6 +126,22 @@
   cursor: pointer;
 }
 
+#islandToolsSlot #toolSeg > label svg {
+  width: 20px;
+  height: 20px;
+  color: rgba(255,255,255,0.85);
+  position: relative;
+  z-index: 1;
+}
+
+#islandToolsSlot #toolSeg > label:has(svg) {
+  background-image: none;
+}
+
+#islandToolsSlot #toolSeg > label:has(svg)::before {
+  display: none;
+}
+
 #islandToolsSlot #toolSeg > label::before{
   content: "";
   width: 20px;

--- a/celstomp/js/input/pointer-events.js
+++ b/celstomp/js/input/pointer-events.js
@@ -14,6 +14,8 @@ let autofill = false;
 let textEntryActive = false;
 let textEntryX = 0;
 let textEntryY = 0;
+let textEntryEditId = null;
+let textEntryNextId = 1;
 
 let trailPoints = [];
 let rectToolStart = null;
@@ -275,7 +277,12 @@ function startStroke(e) {
       return;
   }
   if (tool === "text") {
-      openTextEntryAt(x, y);
+      const editTarget = findTextEntryAtPoint(activeLayer, currentFrame, x, y);
+      if (editTarget) {
+          openTextEntryAt(editTarget.entry.x, editTarget.entry.y, editTarget);
+      } else {
+          openTextEntryAt(x, y);
+      }
       return;
   }
   if (tool === "rect") {
@@ -1596,72 +1603,354 @@ function fillFromLineart(F) {
     return true;
 }
 
-function openTextEntryAt(cx, cy) {
+function textEntryFont(entry) {
+    const bold = entry.bold ? "bold " : "";
+    const italic = entry.italic ? "italic " : "";
+    const size = Math.max(8, Math.min(200, Number(entry.fontSize) || 32));
+    const family = entry.fontFamily || "Arial";
+    return `${italic}${bold}${size}px ${family}`;
+}
+
+function ensureTextEntries(canvas) {
+    if (!canvas) return [];
+    if (!Array.isArray(canvas._textEntries)) canvas._textEntries = [];
+    return canvas._textEntries;
+}
+
+function measureTextEntryBounds(ctx, entry) {
+    if (!ctx || !entry) {
+        return {
+            minX: 0,
+            minY: 0,
+            maxX: 0,
+            maxY: 0
+        };
+    }
+    ctx.save();
+    ctx.font = textEntryFont(entry);
+    ctx.textAlign = entry.align || "left";
+    ctx.textBaseline = "top";
+    const text = String(entry.text || "");
+    const lines = text.split("\n");
+    const lineHeight = Math.max(1, Number(entry.lineHeight) || Math.max(8, Number(entry.fontSize) || 32) * 1.2);
+    let minX = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    for (const line of lines) {
+        const width = Math.max(0, ctx.measureText(line).width);
+        let lineMinX = entry.x;
+        let lineMaxX = entry.x + width;
+        if (entry.align === "center") {
+            lineMinX = entry.x - width / 2;
+            lineMaxX = entry.x + width / 2;
+        } else if (entry.align === "right") {
+            lineMinX = entry.x - width;
+            lineMaxX = entry.x;
+        }
+        minX = Math.min(minX, lineMinX);
+        maxX = Math.max(maxX, lineMaxX);
+    }
+    if (!isFinite(minX)) {
+        minX = entry.x;
+        maxX = entry.x;
+    }
+    const strokePad = entry.strokeEnabled ? Math.max(1, Number(entry.strokeWidth) || 2) : 0;
+    const bounds = {
+        minX: minX - strokePad - 2,
+        minY: entry.y - strokePad - 2,
+        maxX: maxX + strokePad + 2,
+        maxY: entry.y + lineHeight * lines.length + strokePad + 2
+    };
+    ctx.restore();
+    return bounds;
+}
+
+function captureTextEntryBase(ctx, bounds) {
+    if (!ctx || !bounds) return null;
+    const x = Math.max(0, Math.floor(bounds.minX));
+    const y = Math.max(0, Math.floor(bounds.minY));
+    const maxW = ctx.canvas?.width || 0;
+    const maxH = ctx.canvas?.height || 0;
+    const w = Math.max(0, Math.ceil(bounds.maxX) - x);
+    const h = Math.max(0, Math.ceil(bounds.maxY) - y);
+    if (!w || !h || x >= maxW || y >= maxH) return null;
+    const cw = Math.min(w, Math.max(0, maxW - x));
+    const ch = Math.min(h, Math.max(0, maxH - y));
+    if (!cw || !ch) return null;
+    try {
+        return {
+            x,
+            y,
+            w: cw,
+            h: ch,
+            image: ctx.getImageData(x, y, cw, ch)
+        };
+    } catch {
+        return null;
+    }
+}
+
+function restoreTextEntryBase(ctx, entry) {
+    if (!ctx || !entry) return;
+    const snap = entry.baseSnapshot;
+    if (snap && snap.image) {
+        try {
+            ctx.putImageData(snap.image, snap.x, snap.y);
+            return;
+        } catch {}
+    }
+    const b = entry.bounds;
+    if (!b) return;
+    const x = Math.max(0, Math.floor(b.minX));
+    const y = Math.max(0, Math.floor(b.minY));
+    const w = Math.max(0, Math.ceil(b.maxX) - x);
+    const h = Math.max(0, Math.ceil(b.maxY) - y);
+    if (w && h) ctx.clearRect(x, y, w, h);
+}
+
+function renderTextEntryToCanvas(ctx, entry) {
+    if (!ctx || !entry) return;
+    ctx.save();
+    ctx.font = textEntryFont(entry);
+    ctx.textBaseline = "top";
+    ctx.textAlign = entry.align || "left";
+    ctx.fillStyle = entry.fillColor || "#000000";
+    if (entry.strokeEnabled) {
+        ctx.lineJoin = "round";
+        ctx.miterLimit = 2;
+        ctx.lineWidth = Math.max(1, Number(entry.strokeWidth) || 2);
+        ctx.strokeStyle = entry.strokeColor || "#000000";
+    }
+    const lines = String(entry.text || "").split("\n");
+    const lineHeight = Math.max(1, Number(entry.lineHeight) || Math.max(8, Number(entry.fontSize) || 32) * 1.2);
+    let lineY = entry.y;
+    for (const line of lines) {
+        if (entry.strokeEnabled) ctx.strokeText(line, entry.x, lineY);
+        ctx.fillText(line, entry.x, lineY);
+        lineY += lineHeight;
+    }
+    ctx.restore();
+}
+
+function findTextEntryAtPoint(layerIndex, frameIndex, x, y) {
+    const layer = layers?.[layerIndex];
+    if (!layer?.sublayers) return null;
+    const order = Array.isArray(layer.suborder) ? layer.suborder : Array.from(layer.sublayers.keys());
+    for (let o = order.length - 1; o >= 0; o--) {
+        const key = order[o];
+        const sub = layer.sublayers.get(key);
+        const canvas = sub?.frames?.[frameIndex];
+        if (!canvas) continue;
+        const entries = canvas._textEntries;
+        if (!Array.isArray(entries) || !entries.length) continue;
+        const ctx = canvas.getContext("2d");
+        for (let i = entries.length - 1; i >= 0; i--) {
+            const entry = entries[i];
+            const bounds = entry.bounds || measureTextEntryBounds(ctx, entry);
+            entry.bounds = bounds;
+            if (x >= bounds.minX && x <= bounds.maxX && y >= bounds.minY && y <= bounds.maxY) {
+                return {
+                    layerIndex,
+                    frameIndex,
+                    key,
+                    canvas,
+                    entry
+                };
+            }
+        }
+    }
+    return null;
+}
+
+function findTextEntryById(layerIndex, frameIndex, id) {
+    if (!id) return null;
+    const layer = layers?.[layerIndex];
+    if (!layer?.sublayers) return null;
+    const order = Array.isArray(layer.suborder) ? layer.suborder : Array.from(layer.sublayers.keys());
+    for (const key of order) {
+        const sub = layer.sublayers.get(key);
+        const canvas = sub?.frames?.[frameIndex];
+        if (!canvas) continue;
+        const entries = canvas._textEntries;
+        if (!Array.isArray(entries) || !entries.length) continue;
+        const entry = entries.find(item => item?.id === id);
+        if (!entry) continue;
+        return {
+            layerIndex,
+            frameIndex,
+            key,
+            canvas,
+            entry
+        };
+    }
+    return null;
+}
+
+function applyTextFormValuesToEntry(entry, options) {
+    entry.text = options.text;
+    entry.fontSize = options.fontSize;
+    entry.fontFamily = options.fontFamily;
+    entry.bold = options.bold;
+    entry.italic = options.italic;
+    entry.align = options.align;
+    entry.strokeEnabled = options.strokeEnabled;
+    entry.strokeWidth = options.strokeWidth;
+    entry.fillColor = options.fillColor;
+    entry.strokeColor = options.strokeColor;
+    entry.lineHeight = options.fontSize * 1.2;
+}
+
+function openTextEntryAt(cx, cy, editTarget = null) {
     const dialog = document.getElementById("canvasTextEntry");
+    const label = document.getElementById("canvasTextEntryLabel");
     const input = document.getElementById("canvasTextEntryInput");
-    if (!dialog) return;
-    textEntryX = Math.round(cx);
-    textEntryY = Math.round(cy);
+    const sizeInput = document.getElementById("canvasTextEntrySize");
+    const fontSelect = document.getElementById("canvasTextEntryFont");
+    const alignSelect = document.getElementById("canvasTextEntryAlign");
+    const boldCheck = document.getElementById("canvasTextEntryBold");
+    const italicCheck = document.getElementById("canvasTextEntryItalic");
+    const strokeCheck = document.getElementById("canvasTextEntryStroke");
+    const strokeWidthInput = document.getElementById("canvasTextEntryStrokeWidth");
+    const applyBtn = document.getElementById("canvasTextEntryApply");
+    if (!dialog || !input) return;
+
+    const entry = editTarget?.entry || null;
+    textEntryEditId = entry?.id || null;
+    textEntryX = Math.round(entry?.x ?? cx);
+    textEntryY = Math.round(entry?.y ?? cy);
     textEntryActive = true;
-    input.value = "";
+
+    if (entry) {
+        input.value = entry.text || "";
+        if (sizeInput) sizeInput.value = String(Math.max(8, Math.min(200, Number(entry.fontSize) || 32)));
+        if (fontSelect) fontSelect.value = entry.fontFamily || "Arial";
+        if (alignSelect) alignSelect.value = entry.align || "left";
+        if (boldCheck) boldCheck.checked = !!entry.bold;
+        if (italicCheck) italicCheck.checked = !!entry.italic;
+        if (strokeCheck) strokeCheck.checked = !!entry.strokeEnabled;
+        if (strokeWidthInput) strokeWidthInput.value = String(Math.max(1, Math.min(16, Number(entry.strokeWidth) || 2)));
+        if (label) label.textContent = "Edit Text";
+        if (applyBtn) applyBtn.textContent = "Update Text";
+    } else {
+        input.value = "";
+        if (alignSelect && !alignSelect.value) alignSelect.value = "left";
+        if (label) label.textContent = "Add Text";
+        if (applyBtn) applyBtn.textContent = "Add Text";
+    }
+
     dialog.hidden = false;
     dialog.classList.add("open");
+    try {
+        const preview = document.getElementById("brushCursorPreview");
+        if (preview) preview.style.display = "none";
+        scheduleBrushPreviewUpdate?.(true);
+    } catch {}
     setTimeout(() => input.focus(), 50);
 }
 
 function closeTextEntry() {
     const dialog = document.getElementById("canvasTextEntry");
+    const label = document.getElementById("canvasTextEntryLabel");
+    const applyBtn = document.getElementById("canvasTextEntryApply");
     if (!dialog) return;
     textEntryActive = false;
+    textEntryEditId = null;
     dialog.hidden = true;
     dialog.classList.remove("open");
+    if (label) label.textContent = "Add Text";
+    if (applyBtn) applyBtn.textContent = "Add Text";
+    try {
+        scheduleBrushPreviewUpdate?.(true);
+    } catch {}
 }
 
 function applyTextEntry() {
     const input = document.getElementById("canvasTextEntryInput");
     const sizeInput = document.getElementById("canvasTextEntrySize");
     const fontSelect = document.getElementById("canvasTextEntryFont");
+    const alignSelect = document.getElementById("canvasTextEntryAlign");
     const boldCheck = document.getElementById("canvasTextEntryBold");
     const italicCheck = document.getElementById("canvasTextEntryItalic");
+    const strokeCheck = document.getElementById("canvasTextEntryStroke");
+    const strokeWidthInput = document.getElementById("canvasTextEntryStrokeWidth");
     if (!input) return;
-    const text = input.value;
-    if (!text) {
+
+    const text = String(input.value || "").replace(/\r/g, "");
+    const options = {
+        text,
+        fontSize: Math.max(8, Math.min(200, parseInt(sizeInput?.value || "32", 10) || 32)),
+        fontFamily: fontSelect?.value || "Arial",
+        align: alignSelect?.value || "left",
+        bold: !!boldCheck?.checked,
+        italic: !!italicCheck?.checked,
+        strokeEnabled: !!strokeCheck?.checked,
+        strokeWidth: Math.max(1, Math.min(16, parseInt(strokeWidthInput?.value || "2", 10) || 2)),
+        fillColor: colorToHex(currentColor),
+        strokeColor: "#000000"
+    };
+
+    const editTarget = textEntryEditId ? findTextEntryById(activeLayer, currentFrame, textEntryEditId) : null;
+    const editEntry = editTarget?.entry || null;
+    const targetLayer = editTarget?.layerIndex ?? activeLayer;
+    const targetFrame = editTarget?.frameIndex ?? currentFrame;
+    const targetKey = editTarget?.key ?? (targetLayer === LAYER.FILL ? fillWhite : options.fillColor);
+
+    if (targetLayer === PAPER_LAYER) {
         closeTextEntry();
         return;
     }
-    const fontSize = Math.max(8, Math.min(200, parseInt(sizeInput?.value || "32", 10) || 32));
-    const fontFamily = fontSelect?.value || "Arial";
-    const bold = boldCheck?.checked ? "bold " : "";
-    const italic = italicCheck?.checked ? "italic " : "";
-    const fontStyle = `${italic}${bold}${fontSize}px ${fontFamily}`;
-    if (activeLayer === PAPER_LAYER) {
+
+    if (!text.trim()) {
+        if (editTarget && editEntry) {
+            beginGlobalHistoryStep(targetLayer, targetFrame, targetKey);
+            pushUndo(targetLayer, targetFrame, targetKey);
+            const ctx = editTarget.canvas.getContext("2d");
+            restoreTextEntryBase(ctx, editEntry);
+            const entries = ensureTextEntries(editTarget.canvas);
+            const idx = entries.indexOf(editEntry);
+            if (idx >= 0) entries.splice(idx, 1);
+            markGlobalHistoryDirty();
+            commitGlobalHistoryStep();
+            recomputeHasContent(targetLayer, targetFrame, targetKey);
+            queueRenderAll();
+            updateTimelineHasContent(targetFrame);
+        }
         closeTextEntry();
         return;
     }
-    const hex = colorToHex(currentColor);
-    const key = activeLayer === LAYER.FILL ? fillWhite : hex;
-    beginGlobalHistoryStep(activeLayer, currentFrame, key);
-    pushUndo(activeLayer, currentFrame, key);
-    const canvas = getFrameCanvas(activeLayer, currentFrame, key);
+
+    beginGlobalHistoryStep(targetLayer, targetFrame, targetKey);
+    pushUndo(targetLayer, targetFrame, targetKey);
+    const canvas = editTarget?.canvas || getFrameCanvas(targetLayer, targetFrame, targetKey);
     if (!canvas) {
         closeTextEntry();
         return;
     }
+
     const ctx = canvas.getContext("2d");
-    ctx.font = fontStyle;
-    ctx.fillStyle = hex;
-    ctx.textBaseline = "top";
-    const lines = text.split("\n");
-    let lineY = textEntryY;
-    for (const line of lines) {
-        ctx.fillText(line, textEntryX, lineY);
-        lineY += fontSize * 1.2;
+    const entries = ensureTextEntries(canvas);
+    let entry = editEntry;
+    if (!entry) {
+        entry = {
+            id: textEntryNextId++,
+            x: textEntryX,
+            y: textEntryY
+        };
+        entries.push(entry);
+    } else {
+        restoreTextEntryBase(ctx, entry);
     }
+
+    applyTextFormValuesToEntry(entry, options);
+    const bounds = measureTextEntryBounds(ctx, entry);
+    entry.baseSnapshot = captureTextEntryBase(ctx, bounds);
+    renderTextEntryToCanvas(ctx, entry);
+    entry.bounds = bounds;
+
     canvas._hasContent = true;
     markGlobalHistoryDirty();
     commitGlobalHistoryStep();
     queueRenderAll();
-    updateTimelineHasContent(currentFrame);
+    updateTimelineHasContent(targetFrame);
     closeTextEntry();
 }
 
@@ -1671,24 +1960,20 @@ function initTextEntry() {
     const applyBtn = document.getElementById("canvasTextEntryApply");
     const input = document.getElementById("canvasTextEntryInput");
     if (!dialog) return;
+    if (dialog.dataset.listenersBound === "1") return;
+    dialog.dataset.listenersBound = "1";
     cancelBtn?.addEventListener("click", closeTextEntry);
     applyBtn?.addEventListener("click", applyTextEntry);
     input?.addEventListener("keydown", e => {
-        if (e.key === "Escape") {
-            e.preventDefault();
-            closeTextEntry();
-        }
-        if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
-            e.preventDefault();
-            applyTextEntry();
-        }
-    });
-    dialog.addEventListener("click", e => {
-        if (e.target === dialog) closeTextEntry();
+        if (e.key === "Escape") e.preventDefault();
     });
 }
 
-document.addEventListener("DOMContentLoaded", initTextEntry);
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initTextEntry);
+} else {
+    initTextEntry();
+}
 
 function drawRectToolPreview(ctx) {
     if (!rectToolStart || !rectToolPreview) return;

--- a/celstomp/js/input/pointer-events.js
+++ b/celstomp/js/input/pointer-events.js
@@ -1787,31 +1787,21 @@ function removeTextEntriesMatching(layerIndex, frameIndex, key, matchBounds) {
     });
     if (!ctx) return false;
 
-    const removed = new Set;
+    let removedCount = 0;
     const kept = [];
     for (const entry of entries) {
         const bounds = entry.bounds || measureTextEntryBounds(ctx, entry);
         entry.bounds = bounds;
         if (matchBounds(bounds, entry)) {
-            removed.add(entry);
+            removedCount++;
         } else {
             kept.push(entry);
         }
     }
-    if (!removed.size) return false;
-
-    for (let i = entries.length - 1; i >= 0; i--) {
-        const entry = entries[i];
-        if (!removed.has(entry)) continue;
-        restoreTextEntryBase(ctx, entry);
-    }
+    if (!removedCount) return false;
 
     entries.length = 0;
     for (const entry of kept) entries.push(entry);
-    for (const entry of entries) {
-        renderTextEntryToCanvas(ctx, entry);
-        entry.bounds = measureTextEntryBounds(ctx, entry);
-    }
 
     return true;
 }

--- a/celstomp/js/input/pointer-events.js
+++ b/celstomp/js/input/pointer-events.js
@@ -16,6 +16,7 @@ let textEntryX = 0;
 let textEntryY = 0;
 let textEntryEditId = null;
 let textEntryNextId = 1;
+let eraseStrokeBounds = null;
 
 let trailPoints = [];
 let rectToolStart = null;
@@ -285,6 +286,7 @@ function startStroke(e) {
       }
       return;
   }
+  resetEraseStrokeBounds();
   if (tool === "rect") {
       isDrawing = true;
       const hex = colorToHex(currentColor);
@@ -415,6 +417,7 @@ function startStroke(e) {
       const eraserRenderSettings = mergeBrushSettings(eraserSettings, {
           size: eraserSize * eraserTilt
       });
+      extendEraseStrokeBounds(x, y, x + .01, y + .01, eraserRenderSettings?.size || eraserSize * eraserTilt);
       stampLine(ctx, x, y, x + .01, y + .01, eraserRenderSettings, "#ffffff", 1, "destination-out");
   }
   markFrameHasContent(activeLayer, currentFrame, strokeHex || hex);
@@ -425,6 +428,32 @@ function startStroke(e) {
 function markFrameHasContent(L, F, colorStr) {
     const c = getFrameCanvas(L, F, colorStr);
     if (c) c._hasContent = true;
+}
+
+function resetEraseStrokeBounds() {
+    eraseStrokeBounds = null;
+}
+
+function extendEraseStrokeBounds(x0, y0, x1, y1, brushSpan) {
+    const span = Math.max(1, Number(brushSpan) || eraserSize || 1);
+    const pad = Math.max(2, span / 2 + 2);
+    const minX = Math.min(x0, x1) - pad;
+    const minY = Math.min(y0, y1) - pad;
+    const maxX = Math.max(x0, x1) + pad;
+    const maxY = Math.max(y0, y1) + pad;
+    if (!eraseStrokeBounds) {
+        eraseStrokeBounds = {
+            minX,
+            minY,
+            maxX,
+            maxY
+        };
+        return;
+    }
+    eraseStrokeBounds.minX = Math.min(eraseStrokeBounds.minX, minX);
+    eraseStrokeBounds.minY = Math.min(eraseStrokeBounds.minY, minY);
+    eraseStrokeBounds.maxX = Math.max(eraseStrokeBounds.maxX, maxX);
+    eraseStrokeBounds.maxY = Math.max(eraseStrokeBounds.maxY, maxY);
 }
 
 function continueStroke(e) {
@@ -502,6 +531,7 @@ function continueStroke(e) {
       const eraserRenderSettings = mergeBrushSettings(eraserSettings, {
           size: eraserSize * eraserTilt
       });
+      extendEraseStrokeBounds(lastPt.x, lastPt.y, x, y, eraserRenderSettings?.size || eraserSize * eraserTilt);
       stampLine(ctx, lastPt.x, lastPt.y, x, y, eraserRenderSettings, "#ffffff", 1, "destination-out");
   }
   lastPt = {
@@ -595,14 +625,16 @@ function endStroke() {
       return;
   }
   if (tool === "eraser" && activeLayer !== PAPER_LAYER) {
-      recomputeHasContent(activeLayer, currentFrame, endKey || activeSubColor?.[activeLayer] || currentColor);
-      if (tool === "eraser" && activeLayer !== PAPER_LAYER) {
-          recomputeHasContent(activeLayer, currentFrame, endKey || activeSubColor?.[activeLayer] || currentColor);
-          updateTimelineHasContent(currentFrame);
-          pruneUnusedSublayers(activeLayer);
+      const eraseKey = resolveKeyFor(activeLayer, endKey || activeSubColor?.[activeLayer] || currentColor);
+      if (eraseStrokeBounds && eraseKey && typeof removeTextEntriesIntersectingRect === "function") {
+          const b = eraseStrokeBounds;
+          removeTextEntriesIntersectingRect(activeLayer, currentFrame, eraseKey, b.minX, b.minY, b.maxX - b.minX, b.maxY - b.minY);
       }
+      if (eraseKey) recomputeHasContent(activeLayer, currentFrame, eraseKey);
       updateTimelineHasContent(currentFrame);
+      pruneUnusedSublayers(activeLayer);
   }
+  resetEraseStrokeBounds();
   if (tool === "fill-brush") {
       const seeds = trailPoints.length ? trailPoints : lastPt ? [ lastPt ] : [];
       if (seeds.length) applyFillRegionsFromSeeds(currentFrame, seeds, activeLayer);
@@ -662,6 +694,9 @@ function endStrokeMobileSafe(e) {
       try {
           _fillEraseAllLayers = false;
       } catch {}
+      try {
+          resetEraseStrokeBounds();
+      } catch {}
       return;
   }
   const F = typeof currentFrame === "number" ? currentFrame : 0;
@@ -686,6 +721,9 @@ function endStrokeMobileSafe(e) {
       try {
           stabilizedPt = null;
       } catch {}
+      try {
+          resetEraseStrokeBounds();
+      } catch {}
       return;
   }
   if (tool === "rect-select") {
@@ -700,6 +738,9 @@ function endStrokeMobileSafe(e) {
       } catch {}
       try {
           stabilizedPt = null;
+      } catch {}
+      try {
+          resetEraseStrokeBounds();
       } catch {}
       return;
   }
@@ -726,6 +767,9 @@ function endStrokeMobileSafe(e) {
       _fillEraseAllLayers = false;
       isDrawing = false;
       try {
+          resetEraseStrokeBounds();
+      } catch {}
+      try {
           endGlobalHistoryStep?.();
       } catch {}
       return;
@@ -744,6 +788,9 @@ function endStrokeMobileSafe(e) {
   } catch {}
   try {
       _fillEraseAllLayers = false;
+  } catch {}
+  try {
+      resetEraseStrokeBounds();
   } catch {}
   try {
     queueClearFx?.();
@@ -1301,6 +1348,7 @@ function eraseFillRegionsFromSeeds(a, b, c, d) {
                 continue;
             }
             const dpx = img.data;
+            let erasedPixels = null;
             let undoPushed = false;
             const ensureUndoOnce = () => {
                 if (undoPushed) return;
@@ -1326,6 +1374,8 @@ function eraseFillRegionsFromSeeds(a, b, c, d) {
                     if (dpx[a4]) {
                         ensureUndoOnce();
                         dpx[a4] = 0;
+                        if (!erasedPixels) erasedPixels = new Uint8Array(w * h);
+                        erasedPixels[idx] = 1;
                         anyHere = true;
                     }
                     if (x + 1 < w) {
@@ -1373,14 +1423,10 @@ function eraseFillRegionsFromSeeds(a, b, c, d) {
             }
             if (!any) continue;
             ctx.putImageData(img, 0, 0);
-            let anyAlpha = false;
-            for (let i = 3; i < dpx.length; i += 4) {
-                if (dpx[i]) {
-                    anyAlpha = true;
-                    break;
-                }
+            if (erasedPixels && typeof removeTextEntriesIntersectingPixelMask === "function") {
+                removeTextEntriesIntersectingPixelMask(L, F, key, erasedPixels, w, h);
             }
-            canvas._hasContent = anyAlpha;
+            canvas._hasContent = recomputeHasContent(L, F, key);
             didAny = true;
         }
         if (didAny) {
@@ -1718,7 +1764,7 @@ function renderTextEntryToCanvas(ctx, entry) {
         ctx.lineJoin = "round";
         ctx.miterLimit = 2;
         ctx.lineWidth = Math.max(1, Number(entry.strokeWidth) || 2);
-        ctx.strokeStyle = entry.strokeColor || "#000000";
+        ctx.strokeStyle = entry.strokeColor || entry.fillColor || "#000000";
     }
     const lines = String(entry.text || "").split("\n");
     const lineHeight = Math.max(1, Number(entry.lineHeight) || Math.max(8, Number(entry.fontSize) || 32) * 1.2);
@@ -1729,6 +1775,102 @@ function renderTextEntryToCanvas(ctx, entry) {
         lineY += lineHeight;
     }
     ctx.restore();
+}
+
+function removeTextEntriesMatching(layerIndex, frameIndex, key, matchBounds) {
+    const canvas = getFrameCanvas(layerIndex, frameIndex, key);
+    if (!canvas) return false;
+    const entries = ensureTextEntries(canvas);
+    if (!entries.length) return false;
+    const ctx = canvas.getContext("2d", {
+        willReadFrequently: true
+    });
+    if (!ctx) return false;
+
+    const removed = new Set;
+    const kept = [];
+    for (const entry of entries) {
+        const bounds = entry.bounds || measureTextEntryBounds(ctx, entry);
+        entry.bounds = bounds;
+        if (matchBounds(bounds, entry)) {
+            removed.add(entry);
+        } else {
+            kept.push(entry);
+        }
+    }
+    if (!removed.size) return false;
+
+    for (let i = entries.length - 1; i >= 0; i--) {
+        const entry = entries[i];
+        if (!removed.has(entry)) continue;
+        restoreTextEntryBase(ctx, entry);
+    }
+
+    entries.length = 0;
+    for (const entry of kept) entries.push(entry);
+    for (const entry of entries) {
+        renderTextEntryToCanvas(ctx, entry);
+        entry.bounds = measureTextEntryBounds(ctx, entry);
+    }
+
+    return true;
+}
+
+function removeTextEntriesIntersectingRect(layerIndex, frameIndex, key, x, y, w, h) {
+    const minX = Math.min(x, x + w);
+    const minY = Math.min(y, y + h);
+    const maxX = Math.max(x, x + w);
+    const maxY = Math.max(y, y + h);
+    return removeTextEntriesMatching(layerIndex, frameIndex, key, bounds => {
+        return !(bounds.maxX < minX || bounds.minX > maxX || bounds.maxY < minY || bounds.minY > maxY);
+    });
+}
+
+function removeTextEntriesIntersectingMask(layerIndex, frameIndex, key, maskCanvas) {
+    if (!maskCanvas) return false;
+    const maskW = maskCanvas.width | 0;
+    const maskH = maskCanvas.height | 0;
+    if (!maskW || !maskH) return false;
+    const maskCtx = maskCanvas.getContext("2d", {
+        willReadFrequently: true
+    });
+    if (!maskCtx) return false;
+    let maskData;
+    try {
+        maskData = maskCtx.getImageData(0, 0, maskW, maskH).data;
+    } catch {
+        return false;
+    }
+    return removeTextEntriesMatching(layerIndex, frameIndex, key, bounds => {
+        const x0 = Math.max(0, Math.floor(bounds.minX));
+        const y0 = Math.max(0, Math.floor(bounds.minY));
+        const x1 = Math.min(maskW, Math.ceil(bounds.maxX));
+        const y1 = Math.min(maskH, Math.ceil(bounds.maxY));
+        if (x0 >= x1 || y0 >= y1) return false;
+        for (let py = y0; py < y1; py++) {
+            for (let px = x0; px < x1; px++) {
+                if (maskData[(py * maskW + px) * 4 + 3] > 0) return true;
+            }
+        }
+        return false;
+    });
+}
+
+function removeTextEntriesIntersectingPixelMask(layerIndex, frameIndex, key, pixelMask, maskW, maskH) {
+    if (!pixelMask || !maskW || !maskH) return false;
+    return removeTextEntriesMatching(layerIndex, frameIndex, key, bounds => {
+        const x0 = Math.max(0, Math.floor(bounds.minX));
+        const y0 = Math.max(0, Math.floor(bounds.minY));
+        const x1 = Math.min(maskW, Math.ceil(bounds.maxX));
+        const y1 = Math.min(maskH, Math.ceil(bounds.maxY));
+        if (x0 >= x1 || y0 >= y1) return false;
+        for (let py = y0; py < y1; py++) {
+            for (let px = x0; px < x1; px++) {
+                if (pixelMask[py * maskW + px]) return true;
+            }
+        }
+        return false;
+    });
 }
 
 function findTextEntryAtPoint(layerIndex, frameIndex, x, y) {
@@ -1875,6 +2017,7 @@ function applyTextEntry() {
     if (!input) return;
 
     const text = String(input.value || "").replace(/\r/g, "");
+    const fillHex = colorToHex(currentColor);
     const options = {
         text,
         fontSize: Math.max(8, Math.min(200, parseInt(sizeInput?.value || "32", 10) || 32)),
@@ -1884,8 +2027,8 @@ function applyTextEntry() {
         italic: !!italicCheck?.checked,
         strokeEnabled: !!strokeCheck?.checked,
         strokeWidth: Math.max(1, Math.min(16, parseInt(strokeWidthInput?.value || "2", 10) || 2)),
-        fillColor: colorToHex(currentColor),
-        strokeColor: "#000000"
+        fillColor: fillHex,
+        strokeColor: fillHex
     };
 
     const editTarget = textEntryEditId ? findTextEntryById(activeLayer, currentFrame, textEntryEditId) : null;

--- a/celstomp/js/input/pointer-events.js
+++ b/celstomp/js/input/pointer-events.js
@@ -294,6 +294,7 @@ function startStroke(e) {
       activeSubColor[activeLayer] = strokeHex;
       ensureSublayer(activeLayer, strokeHex);
       renderLayerSwatches(activeLayer);
+      invalidateEditableTextEntriesForCanvas(activeLayer, currentFrame, strokeHex);
       beginGlobalHistoryStep(activeLayer, currentFrame, strokeHex);
       rectToolStart = { x, y };
       rectToolPreview = { x, y };
@@ -305,6 +306,10 @@ function startStroke(e) {
       return;
   }
   if (tool === "lasso-fill") {
+      if (activeLayer !== PAPER_LAYER) {
+          const lassoFillKey = colorToHex(currentColor);
+          invalidateEditableTextEntriesForCanvas(activeLayer, currentFrame, lassoFillKey);
+      }
       lassoActive = true;
       isDrawing = true;
       lassoPts = [];
@@ -321,6 +326,8 @@ function startStroke(e) {
   } catch {}
   if (tool === "lasso-erase") {
       if (activeLayer === PAPER_LAYER) return;
+      const lassoEraseKey = resolveKeyFor(activeLayer, activeSubColor?.[activeLayer] ?? currentColor);
+      if (lassoEraseKey) invalidateEditableTextEntriesForCanvas(activeLayer, currentFrame, lassoEraseKey);
       lassoActive = true;
       isDrawing = true;
       lassoPts = [];
@@ -352,6 +359,7 @@ function startStroke(e) {
       if (tool === "fill-brush" && !key) return;
       if (tool === "fill-eraser") key = key || null;
       if (tool === "fill-brush") ensureActiveSwatchForColorLayer(activeLayer, key);
+      if (key) invalidateEditableTextEntriesForCanvas(activeLayer, currentFrame, key);
       if (tool === "fill-brush") pushUndo(activeLayer, currentFrame, key);
       isDrawing = true;
       if (tool === "fill-eraser") _fillEraseAllLayers = !!e.shiftKey;
@@ -378,6 +386,7 @@ function startStroke(e) {
       activeSubColor[activeLayer] = strokeHex;
       ensureSublayer(activeLayer, strokeHex);
       renderLayerSwatches(activeLayer);
+      invalidateEditableTextEntriesForCanvas(activeLayer, currentFrame, strokeHex);
       beginGlobalHistoryStep(activeLayer, currentFrame, strokeHex);
       lineToolStart = { x, y };
       lineToolPreview = { x, y };
@@ -392,6 +401,7 @@ function startStroke(e) {
   activeSubColor[activeLayer] = strokeHex;
   ensureSublayer(activeLayer, strokeHex);
   renderLayerSwatches(activeLayer);
+  invalidateEditableTextEntriesForCanvas(activeLayer, currentFrame, strokeHex);
   beginGlobalHistoryStep(activeLayer, currentFrame, strokeHex);
   pushUndo(activeLayer, currentFrame, strokeHex);
   lastPt = {
@@ -1016,6 +1026,7 @@ function beginRectSelect(e) {
         const inY = pt.y >= rectSelection.y && pt.y <= rectSelection.y + rectSelection.h;
         const sameTarget = rectSelection.L === activeLayer && rectSelection.F === currentFrame && rectSelection.key === key;
         if (inX && inY && sameTarget) {
+            invalidateEditableTextEntriesForCanvas(activeLayer, currentFrame, key);
             const c = getFrameCanvas(activeLayer, currentFrame, key);
             const ctx = c.getContext("2d", {
                 willReadFrequently: true
@@ -1661,6 +1672,18 @@ function ensureTextEntries(canvas) {
     if (!canvas) return [];
     if (!Array.isArray(canvas._textEntries)) canvas._textEntries = [];
     return canvas._textEntries;
+}
+
+function invalidateEditableTextEntriesForCanvas(layerIndex, frameIndex, key) {
+    if (layerIndex === PAPER_LAYER) return false;
+    const resolvedKey = resolveKeyFor(layerIndex, key);
+    if (!resolvedKey) return false;
+    const layer = layers?.[layerIndex];
+    const sub = layer?.sublayers?.get?.(resolvedKey);
+    const canvas = sub?.frames?.[frameIndex];
+    if (!canvas || !Array.isArray(canvas._textEntries) || !canvas._textEntries.length) return false;
+    canvas._textEntries.length = 0;
+    return true;
 }
 
 function measureTextEntryBounds(ctx, entry) {

--- a/celstomp/js/tools/brush-helper.js
+++ b/celstomp/js/tools/brush-helper.js
@@ -88,6 +88,9 @@ function initBrushCursorPreview(inputCanvasEl) {
     try {
         $("eraserSizeInput")?.addEventListener("input", () => scheduleBrushPreviewUpdate(true));
     } catch {}
+    try {
+        $("canvasTextEntrySize")?.addEventListener("input", () => scheduleBrushPreviewUpdate(true));
+    } catch {}
     document.addEventListener("change", e => {
         const t = e.target;
         if (!(t instanceof HTMLInputElement)) return;
@@ -314,9 +317,14 @@ function getBrushSizeForPreview(toolKind) {
 }
 function updateBrushPreview() {
     if (!_brushPrevEl || !_brushPrevCanvas) return;
+    if (typeof textEntryActive !== "undefined" && textEntryActive) {
+        _brushPrevEl.style.display = "none";
+        return;
+    }
     const toolKind = getActiveToolKindForPreview();
-    const showForTools = toolKind === "brush" || toolKind === "eraser" || toolKind === "line" || toolKind === "rect";
+    const showForTools = toolKind === "brush" || toolKind === "eraser" || toolKind === "line" || toolKind === "rect" || toolKind === "text";
     const isEraser = toolKind === "eraser";
+    const isText = toolKind === "text";
     if (!showForTools) {
         _brushPrevEl.style.display = "none";
         return;
@@ -326,6 +334,25 @@ function updateBrushPreview() {
     const cx = pt.x;
     const cy = pt.y;
     const z = typeof getZoom() === "number" && isFinite(getZoom()) ? getZoom() : 1;
+    if (isText) {
+        const textSizeInput = document.getElementById("canvasTextEntrySize");
+        const textSize = Math.max(8, Math.min(200, parseInt(textSizeInput?.value || "32", 10) || 32));
+        const heightCssPx = Math.max(12, Math.min(128, Math.round(textSize * z)));
+        _brushPrevEl.classList.add("simple");
+        _brushPrevEl.classList.remove("eraser");
+        _brushPrevEl.style.left = `${cx}px`;
+        _brushPrevEl.style.top = `${cy}px`;
+        _brushPrevEl.style.width = "2px";
+        _brushPrevEl.style.height = `${heightCssPx}px`;
+        _brushPrevEl.style.border = "none";
+        _brushPrevEl.style.borderRadius = "0";
+        _brushPrevEl.style.boxShadow = "none";
+        _brushPrevEl.style.background = "rgba(255,255,255,.95)";
+        _brushPrevEl.style.clipPath = "none";
+        _brushPrevEl.style.transform = "translate(-50%, -50%)";
+        _brushPrevEl.style.display = "block";
+        return;
+    }
     const settings = isEraser ? eraserSettings : brushSettings;
     const renderSettings = normalizedBrushRenderSettings(settings);
     const shape = brushShapeForType(renderSettings.shape || "circle");
@@ -335,6 +362,7 @@ function updateBrushPreview() {
     const heightCssPx = Math.max(2, dim.h * z);
     _brushPrevEl.classList.remove("simple");
     _brushPrevEl.classList.toggle("eraser", !!isEraser);
+    _brushPrevEl.style.background = "transparent";
     _brushPrevEl.style.border = "1px solid rgba(255,255,255,.95)";
     _brushPrevEl.style.boxShadow = "0 0 0 1px rgba(0,0,0,.78)";
     _brushPrevEl.style.borderStyle = isEraser ? "dashed" : "solid";

--- a/celstomp/js/tools/lasso-helper.js
+++ b/celstomp/js/tools/lasso-helper.js
@@ -128,27 +128,18 @@ function applyLassoErase() {
     if (!ctx) return false;
     const w = off.width | 0, h = off.height | 0;
     const aaOn = getBrushAntiAliasEnabled();
-    if (aaOn) {
-        ctx.save();
-        ctx.globalCompositeOperation = "destination-out";
-        ctx.fillStyle = "rgba(0,0,0,1)";
-        ctx.beginPath();
-        ctx.moveTo(lassoPts[0].x, lassoPts[0].y);
-        for (let i = 1; i < lassoPts.length; i++) ctx.lineTo(lassoPts[i].x, lassoPts[i].y);
-        ctx.closePath();
-        ctx.fill();
-        ctx.restore();
-    } else {
-        let mctx;
-        [_lassoMaskC, mctx] = ensureTmpCanvas(_lassoMaskC, w, h);
-        mctx.save();
-        mctx.fillStyle = "#fff";
-        mctx.beginPath();
-        mctx.moveTo(lassoPts[0].x, lassoPts[0].y);
-        for (let i = 1; i < lassoPts.length; i++) mctx.lineTo(lassoPts[i].x, lassoPts[i].y);
-        mctx.closePath();
-        mctx.fill();
-        mctx.restore();
+    let mctx;
+    [_lassoMaskC, mctx] = ensureTmpCanvas(_lassoMaskC, w, h);
+    mctx.save();
+    mctx.fillStyle = "#fff";
+    mctx.beginPath();
+    mctx.moveTo(lassoPts[0].x, lassoPts[0].y);
+    for (let i = 1; i < lassoPts.length; i++) mctx.lineTo(lassoPts[i].x, lassoPts[i].y);
+    mctx.closePath();
+    mctx.fill();
+    mctx.restore();
+
+    if (!aaOn) {
         const img = mctx.getImageData(0, 0, w, h);
         const d = img.data;
         for (let i = 0; i < d.length; i += 4) {
@@ -159,11 +150,17 @@ function applyLassoErase() {
             d[i + 2] = 255;
         }
         mctx.putImageData(img, 0, 0);
-        ctx.save();
-        ctx.globalCompositeOperation = "destination-out";
-        ctx.drawImage(_lassoMaskC, 0, 0);
-        ctx.restore();
     }
+
+    if (typeof removeTextEntriesIntersectingMask === "function") {
+        removeTextEntriesIntersectingMask(L, currentFrame, key, _lassoMaskC);
+    }
+
+    ctx.save();
+    ctx.globalCompositeOperation = "destination-out";
+    ctx.drawImage(_lassoMaskC, 0, 0);
+    ctx.restore();
+
     recomputeHasContent(L, currentFrame, key);
     queueRenderAll();
     updateTimelineHasContent(currentFrame);

--- a/celstomp/js/ui/interaction-shortcuts.js
+++ b/celstomp/js/ui/interaction-shortcuts.js
@@ -605,7 +605,9 @@ function wireKeyboardShortcuts() {
       5: "lasso-fill",
       6: "lasso-erase",
       7: "rect-select",
-      8: "eyedropper"
+      8: "eyedropper",
+      9: "text",
+      t: "text"
   };
   document.addEventListener("keydown", e => {
       if (e.defaultPrevented) return;

--- a/celstomp/js/ui/interaction-shortcuts.js
+++ b/celstomp/js/ui/interaction-shortcuts.js
@@ -643,13 +643,14 @@ function wireKeyboardShortcuts() {
       2: "eraser",
       3: "line",
       4: "rect",
-      5: "fill-brush",
-      6: "fill-eraser",
-      7: "lasso-fill",
-      8: "lasso-erase",
-      9: "rect-select",
-      0: "eyedropper",
-      t: "text"
+      5: "text",
+      6: "fill-brush",
+      7: "fill-eraser",
+      8: "lasso-fill",
+      9: "lasso-erase",
+      0: "rect-select",
+      t: "text",
+      i: "eyedropper"
   };
   document.addEventListener("keydown", e => {
       if (e.defaultPrevented) return;
@@ -700,6 +701,7 @@ function onWindowKeyDown(e) {
         const typing = tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || e.target && e.target.isContentEditable;
         if (!typing && !ctrl && !e.altKey) {
             const isDigit = n => e.code === `Digit${n}` || e.code === `Numpad${n}` || e.key === String(n);
+            const keyLower = (e.key || "").toLowerCase();
             const pickTool = ({id: id, value: value, altIds: altIds = []}) => {
                 let inp = id && $(id) || null;
                 if (!inp) {
@@ -750,25 +752,32 @@ function onWindowKeyDown(e) {
                 if (isDigit(5)) {
                     e.preventDefault();
                     pickTool({
+                        id: "tool-text",
+                        value: "text"
+                    });
+                }
+                if (isDigit(6)) {
+                    e.preventDefault();
+                    pickTool({
                         id: "tool-fillbrush",
                         value: "fill-brush"
                     });
                 }
-                if (isDigit(6)) {
+                if (isDigit(7)) {
                     e.preventDefault();
                     pickTool({
                         id: "tool-filleraser",
                         value: "fill-eraser"
                     });
                 }
-                if (isDigit(7)) {
+                if (isDigit(8)) {
                     e.preventDefault();
                     pickTool({
                         id: "tool-lassoFill",
                         value: "lasso-fill"
                     });
                 }
-                if (isDigit(8)) {
+                if (isDigit(9)) {
                     e.preventDefault();
                     pickTool({
                         id: "tool-lassoErase",
@@ -776,14 +785,21 @@ function onWindowKeyDown(e) {
                         value: "lasso-erase"
                     });
                 }
-                if (isDigit(9)) {
+                if (isDigit(0)) {
                     e.preventDefault();
                     pickTool({
                         id: "tool-rectSelect",
                         value: "rect-select"
                     });
                 }
-                if (isDigit(0)) {
+                if (keyLower === "t") {
+                    e.preventDefault();
+                    pickTool({
+                        id: "tool-text",
+                        value: "text"
+                    });
+                }
+                if (keyLower === "i") {
                     e.preventDefault();
                     pickTool({
                         id: "tool-eyedropper",
@@ -861,6 +877,9 @@ function onWindowKeyDown(e) {
         e.preventDefault();
         redo();
     } else if (e.key === " ") {
+        const tag = e.target && e.target.tagName ? e.target.tagName.toUpperCase() : "";
+        const typing = tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || e.target && e.target.isContentEditable;
+        if (typing) return;
         e.preventDefault();
         if (isPlaying) pausePlayback(); else startPlayback();
     } else if (e.key === "ArrowUp") {

--- a/celstomp/js/ui/interaction-shortcuts.js
+++ b/celstomp/js/ui/interaction-shortcuts.js
@@ -840,6 +840,9 @@ function onWindowKeyDown(e) {
             });
             if (ctx) {
                 beginGlobalHistoryStep(rectSelection.L, rectSelection.F, rectSelection.key);
+                if (typeof removeTextEntriesIntersectingRect === "function") {
+                    removeTextEntriesIntersectingRect(rectSelection.L, rectSelection.F, rectSelection.key, rectSelection.x, rectSelection.y, rectSelection.w, rectSelection.h);
+                }
                 ctx.clearRect(rectSelection.x, rectSelection.y, rectSelection.w, rectSelection.h);
                 markGlobalHistoryDirty();
                 recomputeHasContent(rectSelection.L, rectSelection.F, rectSelection.key);

--- a/celstomp/js/ui/ui-components.js
+++ b/celstomp/js/ui/ui-components.js
@@ -4,6 +4,7 @@
     const tools = [
         { id: 'tool-brush', val: 'brush', label: 'Brush', checked: true },
         { id: 'tool-eraser', val: 'eraser', label: 'Eraser' },
+        { id: 'tool-text', val: 'text', label: 'Text', icon: '<svg viewBox="0 0 24 24" width="18" height="18"><path d="M4 7V4h16v3M9 20h6M12 4v16" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>' },
         { id: 'tool-fillbrush', val: 'fill-brush', label: 'Fill Brush' },
         { id: 'tool-filleraser', val: 'fill-eraser', label: 'Eraser Fill' },
         { id: 'tool-lassoFill', val: 'lasso-fill', label: 'Lasso Fill' },
@@ -27,7 +28,12 @@
             const lbl = document.createElement('label');
             lbl.htmlFor = t.id;
             lbl.dataset.tool = t.val;
-            lbl.textContent = t.label;
+            lbl.setAttribute('aria-label', t.label);
+            if (t.icon) {
+                lbl.innerHTML = t.icon;
+            } else {
+                lbl.textContent = t.label;
+            }
 
             if (t.val === 'brush') lbl.id = 'toolBrushLabel';
             if (t.val === 'eraser') lbl.id = 'toolEraserLabel';

--- a/celstomp/parts/modals.js
+++ b/celstomp/parts/modals.js
@@ -58,6 +58,8 @@ document.getElementById('part-modals').innerHTML = `
         <div class="shortcutRow"><kbd>6</kbd><span>Lasso Erase</span></div>
         <div class="shortcutRow"><kbd>7</kbd><span>Rect Select</span></div>
         <div class="shortcutRow"><kbd>8</kbd><span>Eyedropper</span></div>
+        <div class="shortcutRow"><kbd>9</kbd><span>Text</span></div>
+        <div class="shortcutRow"><kbd>T</kbd><span>Text</span></div>
       </div>
       <div class="shortcutSection">
         <h4>Navigation</h4>
@@ -223,6 +225,41 @@ document.getElementById('part-modals').innerHTML = `
     <div class="modalActions">
       <button id="autosaveIntervalCancelBtn" type="button">Cancel</button>
       <button id="autosaveIntervalConfirmBtn" type="button">Apply</button>
+    </div>
+  </div>
+
+  <div id="canvasTextEntry" class="canvasTextEntry" role="dialog" aria-modal="true" aria-labelledby="canvasTextEntryLabel" hidden>
+    <div class="canvasTextEntryCard">
+      <div id="canvasTextEntryLabel" class="canvasTextEntryLabel">Add Text</div>
+      <textarea id="canvasTextEntryInput" class="canvasTextEntryInput" rows="3" placeholder="Enter text..."></textarea>
+      <div class="canvasTextEntryOptions">
+        <div class="canvasTextEntryOpt">
+          <span>Font Size</span>
+          <input id="canvasTextEntrySize" class="canvasTextEntryNum" type="number" min="8" max="200" value="32" />
+        </div>
+        <div class="canvasTextEntryOpt">
+          <span>Font</span>
+          <select id="canvasTextEntryFont" class="canvasTextEntrySelect">
+            <option value="Arial">Arial</option>
+            <option value="Georgia">Georgia</option>
+            <option value="Courier New">Courier New</option>
+            <option value="Times New Roman">Times New Roman</option>
+            <option value="Verdana">Verdana</option>
+          </select>
+        </div>
+        <label class="canvasTextEntryOpt canvasTextEntryOptCheck">
+          <input id="canvasTextEntryBold" type="checkbox" />
+          <span>Bold</span>
+        </label>
+        <label class="canvasTextEntryOpt canvasTextEntryOptCheck">
+          <input id="canvasTextEntryItalic" type="checkbox" />
+          <span>Italic</span>
+        </label>
+      </div>
+      <div class="canvasTextEntryActions">
+        <button id="canvasTextEntryCancel" class="canvasTextEntryBtn" type="button">Cancel</button>
+        <button id="canvasTextEntryApply" class="canvasTextEntryBtn canvasTextEntryBtnPrimary" type="button">Add Text</button>
+      </div>
     </div>
   </div>
 `;

--- a/celstomp/parts/modals.js
+++ b/celstomp/parts/modals.js
@@ -253,6 +253,18 @@ document.getElementById('part-modals').innerHTML = `
             <option value="Verdana">Verdana</option>
           </select>
         </div>
+        <div class="canvasTextEntryOpt">
+          <span>Align</span>
+          <select id="canvasTextEntryAlign" class="canvasTextEntrySelect">
+            <option value="left">Left</option>
+            <option value="center">Center</option>
+            <option value="right">Right</option>
+          </select>
+        </div>
+        <div class="canvasTextEntryOpt">
+          <span>Outline Width</span>
+          <input id="canvasTextEntryStrokeWidth" class="canvasTextEntryNum" type="number" min="1" max="16" value="2" />
+        </div>
         <label class="canvasTextEntryOpt canvasTextEntryOptCheck">
           <input id="canvasTextEntryBold" type="checkbox" />
           <span>Bold</span>
@@ -260,6 +272,10 @@ document.getElementById('part-modals').innerHTML = `
         <label class="canvasTextEntryOpt canvasTextEntryOptCheck">
           <input id="canvasTextEntryItalic" type="checkbox" />
           <span>Italic</span>
+        </label>
+        <label class="canvasTextEntryOpt canvasTextEntryOptCheck">
+          <input id="canvasTextEntryStroke" type="checkbox" />
+          <span>Outline</span>
         </label>
       </div>
       <div class="canvasTextEntryActions">


### PR DESCRIPTION
## Description
Add a text tool with rich in-app editor accessible via key 5.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- Add text tool to tool selector with SVG icon
- Create in-app text entry overlay (no browser prompts)
- Support font family, size, weight, italic, alignment options
- Add stroke/outline toggle with width control
- Implement click-to-edit existing text
- Add cursor preview support

## Testing
- [x] Tested in Firefox

**Test Configuration:**
- OS: Windows 10
- Browser: Firefox

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested my changes thoroughly

## Related Issues
N/A
