### PR TITLE
[nightshift] readme-improvements: fix stale URLs, add contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ I come from an art background and built this while learning to code.
 Clone the repository:
 
 ```bash
-git clone https://github.com/ginyoa/celstomp_v1.git
-cd celstomp_v1
+git clone https://github.com/Celstomp/celstomp.git
+cd celstomp
 ```
 
 #### Using Vite (recommended)
@@ -106,6 +106,16 @@ The Python server will start at http://localhost:8000
 
 **Browser:** Chrome, Firefox, Safari, or Edge
 
+## Contributing
+
+Contributions are welcome! Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/my-feature`)
+3. Commit your changes (`git commit -m 'Add my feature'`)
+4. Push to the branch (`git push origin feature/my-feature`)
+5. Open a Pull Request
+
 ## License
 
-See LICENSE file.
+This project is licensed under the [GNU General Public License v3.0](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ We take the security of Celstomp seriously. If you believe you have found a secu
 
 Instead, please report security vulnerabilities by creating a private security advisory:
 
-1. Go to the [Security Advisories](https://github.com/ginyoa/celstomp_v1/security/advisories) page
+1. Go to the [Security Advisories](https://github.com/Celstomp/celstomp/security/advisories) page
 2. Click "New draft security advisory"
 3. Fill in the details about the vulnerability
 4. Submit the advisory


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** readme-improvements
**Category:** pr
**Changes:**
- Update clone URL from `ginyoa/celstomp_v1` to `Celstomp/celstomp` (repo was transferred to org)
- Update SECURITY.md advisory URL to match current repo location
- Add Contributing section with steps and Code of Conduct reference
- Improve License section with proper GPL-3.0 link

Merge if useful, close if not.